### PR TITLE
Merge Map Module into Dev

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,18 +9,30 @@ mod prelude {
     pub use crate::map::*;
 }
 
-struct State {}
+use prelude::*;
+
+struct State {
+    map: Map,
+}
+
+impl State {
+    fn new() -> Self {
+        Self { map: Map::new() }
+    }
+}
 
 impl GameState for State {
     fn tick(&mut self, ctx: &mut BTerm) {
         ctx.cls();
-        ctx.print(1, 1, "Hello, Bracket Terminal!");
+        self.map.render(ctx);
     }
 }
 
 fn main() -> BError {
     let context = BTermBuilder::simple80x50()
         .with_title("Rusty Corridors")
+        .with_fps_cap(30.0)
         .build()?;
-    main_loop(context, State {})
+
+    main_loop(context, State::new())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,14 @@
 use bracket_lib::prelude::*;
 
+mod map;
+
+mod prelude {
+    pub use bracket_lib::prelude::*;
+    pub const SCREEN_WIDTH: i32 = 80;
+    pub const SCREEN_HEIGHT: i32 = 50;
+    pub use crate::map::*;
+}
+
 struct State {}
 
 impl GameState for State {

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,0 +1,2 @@
+use crate::prelude::*;
+const NUM_TILES: usize = (SCREEN_WIDTH * SCREEN_HEIGHT) as usize;

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,3 +6,15 @@ pub enum TileType {
     Wall,
     Floor,
 }
+
+pub struct Map {
+    pub tiles: Vec<TileType>,
+}
+
+impl Map {
+    pub fn new() -> Self {
+        Self {
+            tiles: vec![TileType::Floor; NUM_TILES],
+        }
+    }
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -18,3 +18,8 @@ impl Map {
         }
     }
 }
+
+// Calculates the tile index from x and y using row-first encoding
+pub fn map_idx(x: i32, y: i32) -> usize {
+    ((y * SCREEN_WIDTH) + x) as usize
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,2 +1,8 @@
 use crate::prelude::*;
 const NUM_TILES: usize = (SCREEN_WIDTH * SCREEN_HEIGHT) as usize;
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum TileType {
+    Wall,
+    Floor,
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -17,9 +17,25 @@ impl Map {
             tiles: vec![TileType::Floor; NUM_TILES],
         }
     }
+
+    pub fn render(&self, ctx: &mut BTerm) {
+        for y in 0..SCREEN_HEIGHT {
+            for x in 0..SCREEN_WIDTH {
+                let idx = map_idx(x, y);
+                match self.tiles[idx] {
+                    TileType::Floor => {
+                        ctx.set(x, y, YELLOW, BLACK, to_cp437('.'));
+                    }
+                    TileType::Wall => {
+                        ctx.set(x, y, GREEN, BLACK, to_cp437('#'));
+                    }
+                }
+            }
+        }
+    }
 }
 
-// Calculates the tile index from x and y using row-first encoding
+// Calculates the tile index from x and y using row-first striding
 pub fn map_idx(x: i32, y: i32) -> usize {
     ((y * SCREEN_WIDTH) + x) as usize
 }


### PR DESCRIPTION
This PR adds a map module and sets up main to use the map module that adds: 
- Prelude for the game's crate.
- Declare constants for screen.
- TileType enum with floor and wall tiles.
- Map struct with a Vector of tiles.
- Function for row-first striding indexing.
- Map render function that draws the wall and floor.
- Map initialization in State and rendering per tick.